### PR TITLE
Fix unresponsive delete button in Dafdaf

### DIFF
--- a/app.js
+++ b/app.js
@@ -1092,108 +1092,106 @@ bot.on('callback_query', async (callbackQuery) => {
                 
                 // רענן את הרשימה
                 await handleRemoveKeyword(chatId, userId);
-            } else if (data.startsWith('share_own_')) {
-                await userHandler.handleSharePost(callbackQuery);
-            } else if (data.startsWith('admin_delete_')) {
-                // מחיקת מודעה על ידי מנהל
-                if (!config.isAdmin(userId)) {
-                    await bot.answerCallbackQuery(callbackQuery.id, {
-                        text: 'אין לך הרשאות מנהל',
-                        show_alert: true
-                    });
-                    return;
-                }
-                
-                const postId = parseInt(data.replace('admin_delete_', ''));
-                
-                // הצג אישור למחיקה
-                const confirmKeyboard = {
-                    reply_markup: {
-                        inline_keyboard: [
-                            [
-                                { text: '✅ אשר מחיקה', callback_data: `confirm_admin_delete_${postId}` },
-                                { text: '❌ ביטול', callback_data: `view_${postId}` }
-                            ]
+            }
+        } else if (data.startsWith('admin_delete_')) {
+            // מחיקת מודעה על ידי מנהל
+            if (!config.isAdmin(userId)) {
+                await bot.answerCallbackQuery(callbackQuery.id, {
+                    text: 'אין לך הרשאות מנהל',
+                    show_alert: true
+                });
+                return;
+            }
+            
+            const postId = parseInt(data.replace('admin_delete_', ''));
+            
+            // הצג אישור למחיקה
+            const confirmKeyboard = {
+                reply_markup: {
+                    inline_keyboard: [
+                        [
+                            { text: '✅ אשר מחיקה', callback_data: `confirm_admin_delete_${postId}` },
+                            { text: '❌ ביטול', callback_data: `view_${postId}` }
                         ]
-                    }
-                };
-                
-                await bot.editMessageText(
-                    '⚠️ *אזהרה: מחיקת מודעה*\n\n' +
-                    'האם אתה בטוח שברצונך למחוק את המודעה?\n' +
-                    'פעולה זו לא ניתנת לביטול.',
-                    {
-                        chat_id: chatId,
-                        message_id: msg.message_id,
-                        parse_mode: 'Markdown',
-                        ...confirmKeyboard
-                    }
-                );
-            } else if (data.startsWith('confirm_admin_delete_')) {
-                // אישור מחיקת מודעה על ידי מנהל
-                if (!config.isAdmin(userId)) {
-                    await bot.answerCallbackQuery(callbackQuery.id, {
-                        text: 'אין לך הרשאות מנהל',
-                        show_alert: true
-                    });
-                    return;
+                    ]
                 }
+            };
+            
+            await bot.editMessageText(
+                '⚠️ *אזהרה: מחיקת מודעה*\n\n' +
+                'האם אתה בטוח שברצונך למחוק את המודעה?\n' +
+                'פעולה זו לא ניתנת לביטול.',
+                {
+                    chat_id: chatId,
+                    message_id: msg.message_id,
+                    parse_mode: 'Markdown',
+                    ...confirmKeyboard
+                }
+            );
+        } else if (data.startsWith('confirm_admin_delete_')) {
+            // אישור מחיקת מודעה על ידי מנהל
+            if (!config.isAdmin(userId)) {
+                await bot.answerCallbackQuery(callbackQuery.id, {
+                    text: 'אין לך הרשאות מנהל',
+                    show_alert: true
+                });
+                return;
+            }
+            
+            const postId = parseInt(data.replace('confirm_admin_delete_', ''));
+            const post = await db.getPost(postId);
+            
+            if (post) {
+                const success = await db.adminDeletePost(postId);
                 
-                const postId = parseInt(data.replace('confirm_admin_delete_', ''));
-                const post = await db.getPost(postId);
-                
-                if (post) {
-                    const success = await db.adminDeletePost(postId);
-                    
-                    if (success) {
-                        await bot.editMessageText(
-                            '✅ *המודעה נמחקה בהצלחה*\n\n' +
-                            `המודעה "${utils.truncateText(post.title, 50)}" הוסרה מהמערכת.`,
-                            {
-                                chat_id: chatId,
-                                message_id: msg.message_id,
-                                parse_mode: 'Markdown',
-                                reply_markup: {
-                                    inline_keyboard: [
-                                        [{ text: '🔙 חזרה לתפריט ראשי', callback_data: 'back_to_main' }]
-                                    ]
-                                }
+                if (success) {
+                    await bot.editMessageText(
+                        '✅ *המודעה נמחקה בהצלחה*\n\n' +
+                        `המודעה "${utils.truncateText(post.title, 50)}" הוסרה מהמערכת.`,
+                        {
+                            chat_id: chatId,
+                            message_id: msg.message_id,
+                            parse_mode: 'Markdown',
+                            reply_markup: {
+                                inline_keyboard: [
+                                    [{ text: '🔙 חזרה לתפריט ראשי', callback_data: 'back_to_main' }]
+                                ]
                             }
-                        );
-                        
-                        utils.logAction(userId, 'admin_delete_post', { postId, postTitle: post.title });
-                    } else {
-                        await bot.answerCallbackQuery(callbackQuery.id, {
-                            text: 'שגיאה במחיקת המודעה',
-                            show_alert: true
-                        });
-                    }
+                        }
+                    );
+                    
+                    utils.logAction(userId, 'admin_delete_post', { postId, postTitle: post.title });
                 } else {
                     await bot.answerCallbackQuery(callbackQuery.id, {
-                        text: 'המודעה לא נמצאה',
+                        text: 'שגיאה במחיקת המודעה',
                         show_alert: true
                     });
                 }
-            } else if (data.startsWith('view_')) {
-                // צפייה במודעה (לאחר ביטול מחיקה)
-                const postId = parseInt(data.replace('view_', ''));
-                const post = await db.getPost(postId);
-                
-                if (post && post.is_active) {
-                    const postMessage = formatPostMessage(post);
-                    await bot.editMessageText(postMessage, {
-                        chat_id: chatId,
-                        message_id: msg.message_id,
-                        parse_mode: 'Markdown',
-                        ...getPostActionsKeyboard(postId, userId)
-                    });
-                    userHandler.trackInteraction(userId, postId, 'view');
-                } else {
-                    await bot.answerCallbackQuery(callbackQuery.id, {
-                        text: 'המודעה לא נמצאה',
-                        show_alert: true
-                    });
-                }
+            } else {
+                await bot.answerCallbackQuery(callbackQuery.id, {
+                    text: 'המודעה לא נמצאה',
+                    show_alert: true
+                });
+            }
+        } else if (data.startsWith('view_')) {
+            // צפייה במודעה (לאחר ביטול מחיקה)
+            const postId = parseInt(data.replace('view_', ''));
+            const post = await db.getPost(postId);
+            
+            if (post && post.is_active) {
+                const postMessage = formatPostMessage(post);
+                await bot.editMessageText(postMessage, {
+                    chat_id: chatId,
+                    message_id: msg.message_id,
+                    parse_mode: 'Markdown',
+                    ...getPostActionsKeyboard(postId, userId)
+                });
+                userHandler.trackInteraction(userId, postId, 'view');
+            } else {
+                await bot.answerCallbackQuery(callbackQuery.id, {
+                    text: 'המודעה לא נמצאה',
+                    show_alert: true
+                });
             }
         } else if (data === 'cancel_operation') {
             // ביטול פעולה


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move admin delete and view callback handlers to the top level to fix the unresponsive delete button in the browse view.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The delete button in the "Browse > All" section was unresponsive because its associated callback handlers (`admin_delete_`, `confirm_admin_delete_`, and `view_`) were incorrectly nested within an `alert_` handling block in `app.js`. This prevented them from being triggered when the button was pressed from a non-alert context. Moving these handlers to the top-level callback routing ensures they are correctly processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-721a9f37-e743-4a4d-b7cc-7e0047fe01ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-721a9f37-e743-4a4d-b7cc-7e0047fe01ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

